### PR TITLE
Unregistred LUA_WARNING event.

### DIFF
--- a/BaudErrorFrame.lua
+++ b/BaudErrorFrame.lua
@@ -12,6 +12,7 @@ function BaudErrorFrame_OnLoad(self)
 	UIParent:UnregisterEvent("ADDON_ACTION_FORBIDDEN")
 	self:RegisterEvent("MACRO_ACTION_FORBIDDEN")
 	UIParent:UnregisterEvent("MACRO_ACTION_FORBIDDEN")
+	UIParent:UnregisterEvent("LUA_WARNING")
 
 	tinsert(UISpecialFrames, self:GetName())
 


### PR DESCRIPTION
В других отлавливателях я видел, кроме отключения, показ ошибок через этот эвент.
Я тестил с ручной ошибкой, и там был повтор ошибки, как и без эвента. Поэтому смысла отслеживания не увидел.
Может есть какие-то особые ошибки, которые показываются только через эвент?